### PR TITLE
Remove dependency on 'check' job in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: check
     steps:
       - name: Checkout codebase
         uses: actions/checkout@v6


### PR DESCRIPTION
This pull request makes a small change to the test workflow configuration by removing the dependency on the `check` job in `.github/workflows/test.yml`. This allows the `test` job to run independently without waiting for the `check` job to complete.