### PR TITLE
ref: move codeowners assignment to github teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-* @vmasdani
-*.yml @vmasdani @aldy505
-.github/ @vmasdani @aldy505
+* @teknologi-umum/backend-rust


### PR DESCRIPTION
This is too noisy for me.
